### PR TITLE
New rule: No unhandled scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # eslint-plugin-enterprise-extras
+
 This plugin adds extra ESLint rules that may be more suitable for an enterprise environment. The rules were created for use within Buildertrend, but feel free to request or propose any ESLint rules that may fall under this umbrella.
 
 ------------
-# Installation
+
+## Installation
+
 Install this ESLint plugin as a dev dependency:
+
 ```bash
 npm install --save-dev eslint-plugin-enterprise-extras
 ```
-# Usage
+
+## Usage
+
 Edit your project's `.eslintrc.js` configuration to load the plugin:
+
 ```js
 module.exports = {
     plugins: ["enterprise-extras"],
@@ -19,7 +26,9 @@ module.exports = {
     }
 }
 ```
+
 Alternatively, you could use the `recommended` or `all` preset rule configurations:
+
 ```js
 module.exports = {
     extends: ["plugin:enterprise-extras/recommended"],
@@ -29,12 +38,17 @@ module.exports = {
     }
 }
 ```
-# Supported Rules
+
+## Supported Rules
+
 ✅ = Recommended
 🔧 = Auto-fixable
 | Name                                               | ✅ | 🔧 | Description |
 | -------------------------------------------------- | - | - | ----------- |
-| [no-href-assignment](/docs/no-href-assignment.md)  | ✅ | 🔧 | Prefers `location.assign` instead of `location.href = ` |
+| [no-href-assignment](/docs/no-href-assignment.md)  | ✅ | 🔧 | Prefers `location.assign` instead of `location.href =` |
 | [private-component-methods](/docs/private-component-methods.md)  | ✅ | 🔧 | Requires that all methods of react components are private (except reserved lifecycle methods) |
-# LICENSE
+| [no-unhandled-scheduling](/docs/no-unhandled-scheduling.md)  | ✅ |  | `setTimeout` and `setInterval` calls should be cleared |
+
+## LICENSE
+
 MIT

--- a/docs/no-href-assignment.md
+++ b/docs/no-href-assignment.md
@@ -1,5 +1,7 @@
 # Disallow href direct assignment (`no-href-assignment`)
+
 This rule prevents direct assignment to `window.location.href` (or similar) for redirection. Instead, `window.location.assign()` is preferred as is easier to mock when testing
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule:
@@ -23,7 +25,11 @@ myLoc.href.assign("http://example.com");
 const location: { href: string } = { href: "" };
 location.href = "test";
 ```
+
 ## When Not To Use It
+
 When you are not concerned with mocking out href/url changes, or are indifferent on which method is used.
+
 ## Auto-fixable?
+
 Yes ✔️

--- a/docs/no-unhandled-scheduling.md
+++ b/docs/no-unhandled-scheduling.md
@@ -1,0 +1,68 @@
+# Avoid unhandled scheduled tasks (`no-unhandled-scheduling`)
+
+This rule suggests that all scheduled task calls (`setTimeout` or `setInterval`) should be handled in some way. In many cases, these scheduled tasks need to be cancelled to avoid leaking resources. React components, in particular, should take great care to ensure that these calls are cleared/released when the component gets unmounted.
+
+Note that the rule **does not** ensure that the schedule handles are cleared at some point, but it does try to be sure that some explicit operation is at least performed on the handle, like an assignment to a variable to be cleared at a later point.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+setTimeout(() => {});
+
+setInterval(() => {});
+
+window.setInterval(() => {});
+
+global.setTimeout(() => {});
+
+class BadComponent extends React.Component {
+  componentDidMount() {
+    setTimeout(() => {
+      // Run operations like setState
+    })
+  }
+
+  render() {
+    return <></>;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+const handle = setTimeout(() => {});
+clearTimeout(handle);
+
+// You can use the VOID keyword to bypass the check
+void setInterval(() => {});
+
+class GoodComponent extends React.Component {
+  timeoutHandle: null | NodeJS.Timeout = null;
+  componentDidMount() {
+    this.timeoutHandle = setTimeout(() => {
+      // Run operations like setState
+    })
+  }
+
+  componentWillUnmount() {
+    if(this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+    }
+  }
+
+  render() {
+    return <></>;
+  }
+}
+```
+
+## When Not To Use It
+
+If you do not care about cancelling scheduled tasks, or find your project uses scheduled tasks very infrequently.
+
+## Auto-fixable?
+
+No ❌

--- a/docs/private-component-methods.md
+++ b/docs/private-component-methods.md
@@ -68,7 +68,11 @@ class GoodExample3 extends React.Component {
   }
 }
 ```
+
 ## When Not To Use It
+
 If you are okay with public methods in your React components and find the pattern acceptable.
+
 ## Auto-fixable?
+
 Yes ✔️

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "eslint-plugin-cameron",
-    "version": "1.0.0",
+    "name": "@c-hess/eslint-plugin-enterprise-extras",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@c-hess/eslint-plugin-enterprise-extras",
   "description": "Extra eslint rules for enterprise environments focusing on React and Typescript",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-    "name": "eslint-plugin-cameron",
-    "description": "ESLint plugin development playground",
+    "name": "eslint-plugin-enterprise-extras",
+    "description": "Additional ESLint rules for enterprise environments",
     "version": "1.0.0",
     "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "dependencies": {
         "@typescript-eslint/eslint-plugin": "^3.10.1",
         "@typescript-eslint/parser": "^3.10.1",
@@ -20,6 +21,7 @@
     },
     "scripts": {
         "build": "tsc",
+        "prepublish": "tsc",
         "test": "jest --watch",
         "test-ci": "jest"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import noHrefAssignment from "./rules/no-href-assignment";
+import noUnhandledScheduling from "./rules/no-unhandled-scheduling";
 import privateComponentMethods from "./rules/private-component-methods";
 
 export = {
   rules: {
     "no-href-assignment": noHrefAssignment,
-    "private-component-methods": privateComponentMethods
+    "private-component-methods": privateComponentMethods,
+    "no-unhandled-scheduling": noUnhandledScheduling,
   },
   configs: {
     recommended: {
@@ -12,6 +14,7 @@ export = {
       rules: {
         "enterprise-extras/no-href-assignment": "error",
         "enterprise-extras/private-component-methods": "error",
+        "enterprise-extras/no-unhandled-scheduling": "warn"
       },
     },
     all: {
@@ -19,6 +22,7 @@ export = {
       rules: {
         "enterprise-extras/no-href-assignment": "error",
         "enterprise-extras/private-component-methods": "error",
+        "enterprise-extras/no-unhandled-scheduling": "error"
       },
     }
   }

--- a/src/rules/no-href-assignment.ts
+++ b/src/rules/no-href-assignment.ts
@@ -27,7 +27,7 @@ const getParentObjectOfMemberExpression = (
 };
 
 const libDomFileNameRegex = /typescript.+lib.+lib\.dom\.d\.ts/
-const isTypeDeclarationFromLibDom = (declaration: Declaration) => {
+const isTypeDeclarationFromLibDom = (declaration: Declaration | undefined | null) => {
   return libDomFileNameRegex.test(declaration?.getSourceFile().fileName);
 };
 
@@ -46,12 +46,12 @@ export default ESLintUtils.RuleCreator(
     fixable: "code",
     docs: {
       category: "Best Practices",
-      recommended: false,
-      description: "Prefer using location.assigned to make testing easier",
+      recommended: "error",
+      description: "Prefer using location.assign() to make testing easier",
     },
     messages: {
       avoidHref:
-        "Prefer using location.assigned instead of href direct assignments",
+        "Prefer using location.assign() instead of href direct assignments",
     },
     schema: [],
   },

--- a/src/rules/no-href-assignment.ts
+++ b/src/rules/no-href-assignment.ts
@@ -38,7 +38,7 @@ const isWindowLocationType = (type: Type) => {
 
 export default ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/C-Hess/eslint-plugin-cameron/blob/main/docs/${name}.md`
+    `https://github.com/C-Hess/eslint-plugin-enterprise-extras/blob/main/docs/${name}.md`
 )<Options, MessageIds>({
   name: "no-href-assignment",
   meta: {

--- a/src/rules/no-unhandled-scheduling.ts
+++ b/src/rules/no-unhandled-scheduling.ts
@@ -1,0 +1,70 @@
+import { ESLintUtils, TSESTree } from "@typescript-eslint/experimental-utils";
+import { isAsExpression, isIdentifier } from "../utils/type-guards";
+
+type MessageIds = "noUnhandledScheduling";
+type Options = [];
+
+const scheduleFuncRegex = /setTimeout|setInterval/;
+const globalVarRegex = /window|global/;
+
+export default ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/C-Hess/eslint-plugin-enterprise-extras/blob/main/docs/${name}.md`
+)<Options, MessageIds>({
+  name: "no-unhandled-scheduling",
+  meta: {
+    type: "suggestion",
+    docs: {
+      category: "Best Practices",
+      recommended: "warn",
+      description:
+        "When using Javascript scheduling (`setTimeout` or `setInterval`), it is recommended to support cancelling of the task, especially within React components.",
+    },
+    messages: {
+      noUnhandledScheduling:
+        "Avoid scheduling uncancellable `{{ scheduleFunc }}` tasks. Use the returned handle to cancel the operation with `{{ scheduleClearFunc }}` when needed.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: function(context) {
+    const reportError = (callExpression: TSESTree.CallExpression) => {
+      let expression: TSESTree.Expression = callExpression.callee;
+
+      // Drill down expression if on global/window objects
+      if (expression.type === "MemberExpression") {
+        if (
+          isIdentifier(expression.object) &&
+          globalVarRegex.test(expression.object.name)
+        ) {
+          expression = expression.property;
+        } else if (
+          isAsExpression(expression.object) &&
+          isIdentifier(expression.object.expression) &&
+          globalVarRegex.test(expression.object.expression.name)
+        ) {
+          expression = expression.property;
+        }
+      }
+
+      // Once we have drilled down, test that we are at an identifier and that it is a schedule function
+      if (isIdentifier(expression) && scheduleFuncRegex.test(expression.name)) {
+        const funcName = expression.name;
+        const clearFuncName = funcName.replace("set", "clear");
+        context.report({
+          node: callExpression,
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: funcName,
+            scheduleClearFunc: clearFuncName,
+          },
+        });
+      }
+    };
+
+    return {
+      "BlockStatement > ExpressionStatement > CallExpression": reportError,
+      "Program > ExpressionStatement > CallExpression": reportError,
+    };
+  },
+});

--- a/src/rules/private-component-methods.ts
+++ b/src/rules/private-component-methods.ts
@@ -29,7 +29,7 @@ const isLifecycleMethod = (
 
 export default ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/C-Hess/eslint-plugin-cameron/blob/main/docs/${name}.md`
+    `https://github.com/C-Hess/eslint-plugin-enterprise-extras/blob/main/docs/${name}.md`
 )<Options, MessageIds>({
   name: "private-component-methods",
   meta: {

--- a/src/rules/private-component-methods.ts
+++ b/src/rules/private-component-methods.ts
@@ -37,7 +37,7 @@ export default ESLintUtils.RuleCreator(
     fixable: "code",
     docs: {
       category: "Best Practices",
-      recommended: false,
+      recommended: "error",
       description:
         "Non-lifecycle methods for React class components should be private to help find unused handlers",
     },

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -23,3 +23,12 @@ export const isMethod = (
     isMethodDefinition(node)
   );
 };
+
+export const isIdentifier = (node: TSESTree.Expression): node is TSESTree.Identifier => {
+  return node.type === "Identifier";
+}
+
+export const isAsExpression = (node: TSESTree.Expression): node is TSESTree.TSAsExpression => {
+  return node.type === "TSAsExpression";
+}
+

--- a/tests/rules/no-unhandled-scheduling.test.ts
+++ b/tests/rules/no-unhandled-scheduling.test.ts
@@ -1,0 +1,145 @@
+import rule from "../../src/rules/no-unhandled-scheduling";
+import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+import { resolve, join } from "path";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: resolve("./node_modules/@typescript-eslint/parser") as any,
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, "../fixtures"),
+    project: "./tsconfig.json",
+  },
+});
+
+ruleTester.run("no-unhandled-scheduling", rule, {
+  valid: [
+    `
+      const handle = setTimeout(() => {});
+    `,
+    `
+      handler(setTimeout(() => {}));
+    `,
+    `
+      () => {
+        let handle = setTimeout(() => {})
+      }
+    `,
+    `
+      const handle = setInterval(() => {});
+    `,
+    `
+      handler(setInterval(() => {}));
+    `,
+    `
+      () => {
+        let handle = setInterval(() => {});
+      }
+    `,
+    `
+      const handle = window.setInterval(() => {});
+    `,
+    ,
+    `
+      const handle = global.setTimeout(() => {});
+    `,
+    `
+      const handle = (window as any).setTimeout(() => {});
+    `,
+    `
+      void setTimeout(() => {});
+    `,
+    `
+      void window.setTimeout(() => {});
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        setTimeout(() => {});
+      `,
+      errors: [
+        {
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: "setTimeout",
+            scheduleClearFunc: "clearTimeout"
+          }
+        },
+      ],
+    },
+    {
+      code: `
+        setInterval(() => {});
+      `,
+      errors: [
+        {
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: "setInterval",
+            scheduleClearFunc: "clearInterval"
+          }
+        },
+      ],
+    },
+    {
+      code: `
+        () => {
+          setTimeout(() => {});
+        }
+      `,
+      errors: [
+        {
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: "setTimeout",
+            scheduleClearFunc: "clearTimeout"
+          }
+        },
+      ],
+    },
+    {
+      code: `
+        () => {
+          global.setInterval(() => {});
+        }
+      `,
+      errors: [
+        {
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: "setInterval",
+            scheduleClearFunc: "clearInterval"
+          }
+        },
+      ],
+    },
+    {
+      code: `
+        window.setTimeout(() => {});
+      `,
+      errors: [
+        {
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: "setTimeout",
+            scheduleClearFunc: "clearTimeout"
+          }
+        },
+      ],
+    },
+    {
+      code: `
+        (window as any).setInterval(() => {});
+      `,
+      errors: [
+        {
+          messageId: "noUnhandledScheduling",
+          data: {
+            scheduleFunc: "setInterval",
+            scheduleClearFunc: "clearInterval"
+          }
+        },
+      ],
+    },
+  ],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "removeComments": true,
     "skipLibCheck": true,
     "sourceMap": false,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "declaration": true
   },
   "include": ["./src/**/*.ts"],
 }


### PR DESCRIPTION
Adds a new rule to help make sure that `setTimeout` and `setInterval` handles are used in some way. This rule is mostly to make sure that `clearTimeout` and `clearInterval` calls are made if needed.